### PR TITLE
Fix flatbuffers response writer bug

### DIFF
--- a/platforms/cpp/core/FlatBuffersResponseWriter.cpp
+++ b/platforms/cpp/core/FlatBuffersResponseWriter.cpp
@@ -19,8 +19,11 @@ bool FlatBuffersResponseWriter::write(const webgrab::DownloadResponse& resp) {
 }
 
 bool FlatBuffersResponseWriter::write(const webgrab::StatusResponse& resp) {
-    // TODO: Implement status response writing
-    return true;
+    builder_.Clear();
+    auto status_str = builder_.CreateString(resp.status()->str());
+    auto fb_resp = webgrab::CreateDownloadStatusResponse(builder_, status_str);
+    builder_.Finish(fb_resp);
+    return sendResponse();
 }
 
 bool FlatBuffersResponseWriter::write(const webgrab::ErrorResponse& resp) {


### PR DESCRIPTION
Implement FlatBuffers serialization and sending for `StatusResponse` to fix a bug where the method incorrectly returned true without writing the response.

---
<a href="https://cursor.com/background-agent?bcId=bc-706f1cdd-d7b5-4cfb-95b2-63fc7ca35220"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-706f1cdd-d7b5-4cfb-95b2-63fc7ca35220"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

